### PR TITLE
[ISSUE #21] Memory corruption in IRunnable.cpp

### DIFF
--- a/changelog.log
+++ b/changelog.log
@@ -1,3 +1,6 @@
+version 3.10.8
+   - Fix: issue #21. Memory corruption in IRunnable.cpp
+
 version 3.10.7a
    - CMake build system refactoring.
 

--- a/runtime/imp/carpc/comm/async/runnable/IRunnable.cpp
+++ b/runtime/imp/carpc/comm/async/runnable/IRunnable.cpp
@@ -26,15 +26,15 @@ const bool IRunnable::send( const application::Context& to_context, const bool i
    }
 
    // Sending blocking Async object
-   carpc::os::ConditionVariable cond_var;
+   std::shared_ptr<carpc::os::ConditionVariable> p_cond_var = std::make_shared<carpc::os::ConditionVariable>();
 
 
-   auto operation_wrapper = [ operation = m_operation, &cond_var ]( )
+   auto operation_wrapper = [ operation = m_operation, p_cond_var ]( )
    {
       if( operation )
          operation( );
 
-      cond_var.notify( );
+      p_cond_var->notify( );
    };
 
    m_operation = operation_wrapper;
@@ -42,8 +42,8 @@ const bool IRunnable::send( const application::Context& to_context, const bool i
    if( false == send_to( to_context ) )
       return false;
 
-   while ( true != cond_var.test( ) )
-      cond_var.wait( );
+   while ( true != p_cond_var->test( ) )
+      p_cond_var->wait( );
 
    return true;
 }


### PR DESCRIPTION
## [ISSUE #21][BUG] Memory corruption in IRunnable.cpp

1. [X] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)? Done.
2. [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change? Done.
3. [X] Have you built the project, and performed manual testing of your functionality for all supported platforms - Linux and Android? Checked only on Android, as issue was reproducible only there.
4. [X] Is your change backward-compatible with the previous version of the framework? Yes. No API changes.

#### Change description:
- Prolonged the life of the ConditionVariable instance inside the IRгnnable::send method

#### Verification criteria:
- Verified on Android with the help of the Address Sanitizer